### PR TITLE
Adding support for per-Ruby environment variables

### DIFF
--- a/bin/rbenv-vars
+++ b/bin/rbenv-vars
@@ -16,6 +16,10 @@ find-rbenv-vars-files() {
     echo "${RBENV_ROOT}/vars"
   fi
 
+  if [ -e "${RBENV_ROOT}/versions/${RBENV_VERSION}/rbenv-vars" ]; then
+    echo "${RBENV_ROOT}/versions/${RBENV_VERSION}/rbenv-vars"
+  fi
+
   local root="$RBENV_DIR"
   local results=""
 


### PR DESCRIPTION
I'm running into trouble with Puppet installing JRuby gems because
JRUBY_HOME isn't set.  Now I can drop an rbenv-vars file in when I install
JRuby and gem installations after that will work properly.
