### PR TITLE
Fall back to $PWD if no vars found in $RBENV_DIR; fixes Pow

### DIFF
--- a/bin/rbenv-vars
+++ b/bin/rbenv-vars
@@ -13,21 +13,13 @@
 set -e
 [ -n "$RBENV_DEBUG" ] && set -x
 
-if [ -z "$RBENV_DIR" ]; then
-  export RBENV_DIR="$(pwd)"
-fi
-
 if [ "$1" = "--version" ] || [ "$1" = "-v" ]; then
   echo "rbenv-vars 1.2.0"
   exit
 fi
 
-find-rbenv-vars-files() {
-  if [ -e "${RBENV_ROOT}/vars" ]; then
-    echo "${RBENV_ROOT}/vars"
-  fi
-
-  local root="$RBENV_DIR"
+traverse-rbenv-vars-files() {
+  local root="$1"
   local results=""
 
   while [ -n "$root" ]; do
@@ -37,7 +29,20 @@ find-rbenv-vars-files() {
     root="${root%/*}"
   done
 
-  echo -n "$results"
+  if [ -n "$results" ]; then
+    echo -n "$results"
+  else
+    return 1
+  fi
+}
+
+find-rbenv-vars-files() {
+  if [ -e "${RBENV_ROOT}/vars" ]; then
+    echo "${RBENV_ROOT}/vars"
+  fi
+
+  traverse-rbenv-vars-files "$RBENV_DIR" ||
+  [ "$RBENV_DIR" = "$PWD" ] || traverse-rbenv-vars-files "$PWD"
 }
 
 sanitize-vars() {


### PR DESCRIPTION
This matches how `rbenv-version-file` searches for `.ruby-version`. $RBENV_DIR might be blank, or it might be a directory of an executable located outside of the current project. If any of this is true, no `.rbenv-vars` files will be found traversing it, so fall back to $PWD and try again.

This fixes `.rbenv-vars` projects files being read in Pow environment, where the primary Ruby process is `/usr/local/opt/pow/libexec/node_modules/nack/bin/nack_worker` and therefore the `ruby` shim initializes RBENV_DIR to `/usr/local/opt/pow/libexec/node_modules/nack/bin`, where no `.rbenv-vars` will be found. In Pow environment, though, $PWD matches the current project's dir.

Fixes #15
