### PR TITLE
If .rbenv-vars isn't present but .env is, use that.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,7 @@ that supports plugin bundles.)
 
 ## Usage
 
-Define environment variables in an `.rbenv-vars` file in your project,
-one variable per line, in the format `VAR=value`. For example:
+Define environment variables in an `.rbenv-vars` or `.env` (for compatibility with [Foreman] (https://github.com/ddollar/foreman)) file in your project, one variable per line, in the format `VAR=value`. For example:
 
     RUBY_GC_MALLOC_LIMIT=50000000
     RUBY_HEAP_MIN_SLOTS=15000

--- a/bin/rbenv-vars
+++ b/bin/rbenv-vars
@@ -25,6 +25,8 @@ traverse-rbenv-vars-files() {
   while [ -n "$root" ]; do
     if [ -e "${root}/.rbenv-vars" ]; then
       results="${root}/.rbenv-vars"$'\n'"$results"
+    elif [ -e "${root}/.env" ]; then
+      results="${root}/.env"$'\n'"$results"
     fi
     root="${root%/*}"
   done


### PR DESCRIPTION
Allows you to use the same file as Foreman (https://github.com/ddollar/foreman), a commonly used tool for developers targeting Heroku (as well as any other environment variable based deployment).