### PR TITLE
Playing nice with Passenger

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ directories of the current directory will be set. Variables from the
 Use the `rbenv vars` command to print all environment variables in the
 order they'll be set.
 
+If using Phusion Passenger, specify the `passenger_ruby`directive to point at the shims directory:
+
+    passenger_ruby /home/user/.rbenv/shims/ruby;
+
 ## Version History
 
 **1.2.0** (January 9, 2013)


### PR DESCRIPTION
How to set `passenger_ruby` directive in `nginx.conf` to point at the shims directory for those using Phusion Passenger. I think if these lines were added it would help clarify how exactly to integrate rbenv-vars with Passenger & Nginx for those having difficulty.