### PR TITLE
Switch the GEM_PATH example to PATH

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ one variable per line, in the format `VAR=value`. For example:
     RUBY_FREE_MIN=4096
 
 You can perform variable substitution with the traditional `$`
-syntax. For example, to append to `GEM_PATH`:
+syntax. For example, to append to `PATH`:
 
-    GEM_PATH=$GEM_PATH:/u/shared/gems
+    PATH=$PATH:/u/my/path
 
 You may also have conditional variable assignments, such that a
 variable will **only** be set if it is not already defined or is blank:


### PR DESCRIPTION
GEM_PATH by default is not set to anything, so this lead to `GEM_PATH=:/u/my/path` which is  probably not what we want. (I got bit by this because ansible-rbenv-role is doing something similar, it prevented bundler of using the default GEM_PATH).

Using PATH is a better way to show the substitution syntax.