### PR TITLE
Add support for per-version environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ command substitution are not allowed. Lines beginning with `#` or any
 lines not in the format VAR=value will be ignored.
 
 Variables specified in the `~/.rbenv/vars` file will be set
-first. Then variables specified in `.rbenv-vars` files in any parent
+first, followed by variables in `~/.rbenv/versions/{version}/vars`. 
+Then variables specified in `.rbenv-vars` files in any parent
 directories of the current directory will be set. Variables from the
 `.rbenv-vars` file in the current directory are set last.
 

--- a/bin/rbenv-vars
+++ b/bin/rbenv-vars
@@ -41,6 +41,10 @@ find-rbenv-vars-files() {
     echo "${RBENV_ROOT}/vars"
   fi
 
+  if [ -e "${RBENV_ROOT}/versions/${RBENV_VERSION}/vars" ]; then
+    echo "${RBENV_ROOT}/versions/${RBENV_VERSION}/vars"
+  fi
+
   traverse-rbenv-vars-files "$RBENV_DIR" ||
   [ "$RBENV_DIR" = "$PWD" ] || traverse-rbenv-vars-files "$PWD"
 }


### PR DESCRIPTION
This PR intends to add the ability to set environment variables on a per-version basis. This can be used for certain projects that require certain env vars to only be set on specific versions, or specific/unusual configs (like the ones found in chefdk).

To attain this goal, the file present at `${RBENV_ROOT}/versions/${RBENV_VERSION}/vars` (e.g. `~/.rbenv/versions/2.3.0/vars`) is read and added just below the global environment configuration.

*NOTE:* This PR is (admittedly) minimally tested, but doesn't appear to break anything too badly.